### PR TITLE
fixed implicit 'ftruncate' declaration

### DIFF
--- a/filehash/ffdb_page.c
+++ b/filehash/ffdb_page.c
@@ -60,6 +60,9 @@
  *
  *
  */
+#if !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 500
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
removes compiler warnings