### PR TITLE
Changed throw() and throw(ExceptionType) declarations to noexcept

### DIFF
--- a/src/DBFunc.cpp
+++ b/src/DBFunc.cpp
@@ -78,7 +78,7 @@ namespace FILEDB
 
   void binaryAllKeys (FFDB_DB* dbh, 
 		      std::vector<std::string>& keys)
-    throw (FileHashDBException)
+    noexcept(false)
   {
     FFDB_DBT  dbkey, dbdata;
     ffdb_cursor_t* crp;
@@ -123,7 +123,7 @@ namespace FILEDB
   void binaryAllPairs (FFDB_DB* dbh, 
 		       std::vector<std::string>& keys, 
 		       std::vector<std::string>& data) 
-    throw (FileHashDBException)
+    noexcept(false)
   {
     FFDB_DBT  dbkey, dbdata;
     ffdb_cursor_t* crp;

--- a/src/DBFunc.h
+++ b/src/DBFunc.h
@@ -65,7 +65,7 @@ namespace FILEDB
    */
   extern void binaryAllKeys (FFDB_DB* dbh, 
 			     std::vector<std::string>& keys)
-    throw (FileHashDBException);
+    noexcept(false);
 
   /**
    * Return all keys and data to vectors in binary form of strings
@@ -74,7 +74,7 @@ namespace FILEDB
   extern void binaryAllPairs (FFDB_DB* dbh, 
 			      std::vector<std::string>& keys, 
 			      std::vector<std::string>& data) 
-    throw (FileHashDBException);
+    noexcept(false);
 
   /**
    * get key and data pair from a database pointed by pointer dbh
@@ -150,7 +150,7 @@ namespace FILEDB
   template <typename K, typename D>
   int insertData (FFDB_DB* dbh, const K& key, const D& data,
 		  unsigned int flag = 0)
-    throw (SerializeException)
+    noexcept(false)
   {
     int ret;
        
@@ -202,7 +202,7 @@ namespace FILEDB
   template <typename K>
   int insertData (FFDB_DB* dbh, const K& key, const std::string& data,
 		  unsigned int flag = 0)
-    throw (SerializeException)
+    noexcept(false)
   {
     int ret;
        
@@ -243,7 +243,7 @@ namespace FILEDB
    * @return 0 on success. Otherwise failure
    */
   template <typename K, typename D>
-  int getData (FFDB_DB* dbh, const K& key, D& data) throw (SerializeException)
+  int getData (FFDB_DB* dbh, const K& key, D& data) noexcept(false)
   {
     int ret = 0;
 
@@ -298,7 +298,7 @@ namespace FILEDB
    * @return 0 on success. Otherwise failure
    */
   template <typename K, typename D>
-  int getData (FFDB_DB* dbh, const K& key, std::string& data) throw (SerializeException)
+  int getData (FFDB_DB* dbh, const K& key, std::string& data) noexcept(false)
   {
     int ret = 0;
 
@@ -340,7 +340,7 @@ namespace FILEDB
    */
   template <typename K, typename D>
   void allKeys (FFDB_DB* dbh, std::vector<K>& keys) 
-    throw (SerializeException, FileHashDBException)
+    noexcept(false)
   {
     FFDB_DBT  dbkey;
     ffdb_cursor_t *crp;
@@ -391,7 +391,7 @@ namespace FILEDB
    */
   template <typename K, typename D>
   void allPairs (FFDB_DB* dbh, std::vector<K>& keys, std::vector<D>& data) 
-    throw (SerializeException, FileHashDBException)
+    noexcept(false)
   {
     FFDB_DBT  dbkey, dbdata;
     ffdb_cursor_t* crp;
@@ -449,7 +449,7 @@ namespace FILEDB
    */
   template <typename K>
   int isDatabaseEmpty (FFDB_DB* dbh)
-    throw (SerializeException, FileHashDBException)
+    noexcept(false)
   {
     FFDB_DBT dbkey, dbdata;
     ffdb_cursor_t* crp;
@@ -497,7 +497,7 @@ namespace FILEDB
    */
   template <typename K>
   int keyExist (FFDB_DB* dbh, const K& arg) 
-    throw (SerializeException)
+    noexcept(false)
   {
     int ret;
     

--- a/src/DBString.cpp
+++ b/src/DBString.cpp
@@ -120,7 +120,7 @@ namespace FILEDB
 
   // A string object is preceded by a magic number and an ID number
   void
-  StringKey::writeObject (std::string& output) const throw (SerializeException)
+  StringKey::writeObject (std::string& output) const noexcept(false)
   {
     ostringstream ostrm;
     unsigned short magicnum = hton_short(StringKey::MAGIC);
@@ -156,7 +156,7 @@ namespace FILEDB
 
   // again we need to retrive magic and serial id for security reason
   void
-  StringKey::readObject (const std::string& input) throw (SerializeException)
+  StringKey::readObject (const std::string& input) noexcept(false)
   {
     istringstream istrm (input);
     unsigned short magicnum, sid;
@@ -274,7 +274,7 @@ namespace FILEDB
   }
 
   void
-  UserData::writeObject (std::string& output) const throw (SerializeException)
+  UserData::writeObject (std::string& output) const noexcept(false)
   {
     ostringstream ostrm;
     unsigned short magicnum = hton_short(UserData::MAGIC);
@@ -309,7 +309,7 @@ namespace FILEDB
   }
 
   void
-  UserData::readObject (const std::string& input) throw (SerializeException)
+  UserData::readObject (const std::string& input) noexcept(false)
   {
     istringstream istrm (input);
     unsigned short magicnum, sid;

--- a/src/DBString.h
+++ b/src/DBString.h
@@ -108,14 +108,14 @@ namespace FILEDB
      * Convert this object into binary form stored in the internal buffer
      *
      */
-    void writeObject (std::string&) const throw (SerializeException);
+    void writeObject (std::string&) const noexcept(false);
 
 
     /**
      * Convert a buffer into an object
      *
      */
-    void readObject (const std::string&)  throw (SerializeException);
+    void readObject (const std::string&)  noexcept(false);
 
 
     /**
@@ -197,14 +197,14 @@ namespace FILEDB
      * Convert this object into binary form stored in the internal buffer
      *
      */
-    void writeObject (std::string&) const throw (SerializeException);
+    void writeObject (std::string&) const noexcept(false);
 
 
     /**
      * Convert a buffer into an object
      *
      */
-    void readObject (const std::string&)  throw (SerializeException);
+    void readObject (const std::string&)  noexcept(false);
    
   private:
     static const unsigned short MAGIC= (unsigned short)0x11ff;

--- a/src/FileDB.cpp
+++ b/src/FileDB.cpp
@@ -69,7 +69,7 @@ namespace FILEDB {
   /**
    * Desstructor
    */
-  SerializeException::~SerializeException (void) throw ()
+  SerializeException::~SerializeException (void) noexcept(true)
   {
     // empty
   }
@@ -78,7 +78,7 @@ namespace FILEDB {
    * Return the reason of this exception
    */
   const char* 
-  SerializeException::what (void) const throw ()
+  SerializeException::what (void) const noexcept(true)
   {
     return (cls_ + ": " + reason_).c_str();
   }
@@ -120,7 +120,7 @@ namespace FILEDB {
   /**
    * Desstructor
    */
-  FileHashDBException::~FileHashDBException (void) throw ()
+  FileHashDBException::~FileHashDBException (void) noexcept(true)
   {
     // empty
   }
@@ -129,7 +129,7 @@ namespace FILEDB {
    * Return the reason of this exception
    */
   const char* 
-  FileHashDBException::what (void) const throw ()
+  FileHashDBException::what (void) const noexcept(true)
   {
     return (cls_ + ": " + reason_).c_str();
   }

--- a/src/FileDB.h
+++ b/src/FileDB.h
@@ -77,12 +77,12 @@ namespace FILEDB
     /**
      * Destructor
      */
-    virtual ~SerializeException (void) throw ();
+    virtual ~SerializeException (void) noexcept(true);
 
     /**
      * Return reason of the exception
      */
-    virtual const char* what (void) const throw ();
+    virtual const char* what (void) const noexcept(true);
 
   protected:
     std::string cls_;
@@ -120,12 +120,12 @@ namespace FILEDB
     /**
      * Destructor
      */
-    virtual ~FileHashDBException (void) throw ();
+    virtual ~FileHashDBException (void) noexcept(true);
 
     /**
      * Return reason of the exception
      */
-    virtual const char* what (void) const throw ();
+    virtual const char* what (void) const noexcept(true);
 
   protected:
     std::string cls_;

--- a/src/Serializable.h
+++ b/src/Serializable.h
@@ -60,13 +60,13 @@ namespace FILEDB
     /**
      * Return this object into a binary form
      */
-    virtual void writeObject (std::string& output) const throw (SerializeException) = 0;
+    virtual void writeObject (std::string& output) const noexcept(false) = 0;
 
 
     /**
      * Convert input object retrieved from database or network into an object
      */
-    virtual void readObject (const std::string& input) throw (SerializeException) = 0;
+    virtual void readObject (const std::string& input) noexcept(false) = 0;
 
 
   protected:

--- a/src/VFloatData.cpp
+++ b/src/VFloatData.cpp
@@ -121,7 +121,7 @@ namespace FILEDB
    * routine is returned, the len contains the object actual length
    */
   void 
-  VFloatData::writeObject (std::string& output) const throw (SerializeException)
+  VFloatData::writeObject (std::string& output) const noexcept(false)
   {
     float* vcfbuf;
     unsigned short id;
@@ -165,7 +165,7 @@ namespace FILEDB
    * @param object a new populated object
    */
   void 
-  VFloatData::readObject (const std::string& input)  throw (SerializeException)
+  VFloatData::readObject (const std::string& input)  noexcept(false)
   {
     float* vcfbuf;
     unsigned short id, pad;

--- a/src/VFloatData.h
+++ b/src/VFloatData.h
@@ -93,14 +93,14 @@ namespace FILEDB
      * Convert this object to a buffer
      *
      */
-    void writeObject (std::string& output) const throw (SerializeException);
+    void writeObject (std::string& output) const noexcept(false);
 
 
     /**
      * Convert a buffer into an object
      *
      */
-    void readObject (const std::string& input) throw (SerializeException);
+    void readObject (const std::string& input) noexcept(false);
 
   };
 }


### PR DESCRIPTION
Hi All, 
 I have had some complaints when building in C++-17 mode about the throw() and throw(ExceptionType) declarations.  Apparently this is a deprecated or at least soon to be removed (in C++-20) and ought to be replace by 'noexcept' 
i.e.  a) func( ... )  throw();   =>  Change  throw() to noexcept; or noexcept(true);
       b) func( .. ).  throw(Foo) => Change throw(Foo) to noexcept(true)

No actual functionality was changed.